### PR TITLE
docs(data-server-state): add Background Refetching and Rollback & Con…

### DIFF
--- a/docs/03-application-architecture/data-server-state/README.md
+++ b/docs/03-application-architecture/data-server-state/README.md
@@ -10,8 +10,10 @@
 - [Cache Keys & Query Identity](cache-keys-and-query-identity.md)
 - [Staleness & Revalidation](staleness-and-revalidation.md)
 - [Cache Invalidation](cache-invalidation.md)
+- [Background Refetching](background-refetching.md)
 - [Mutation Lifecycle](mutation-lifecycle.md)
 - [Optimistic Updates](optimistic-updates.md)
+- [Rollback & Conflict Resolution](rollback-and-conflict-resolution.md)
 
 ## Taxonomy
 

--- a/docs/03-application-architecture/data-server-state/background-refetching.md
+++ b/docs/03-application-architecture/data-server-state/background-refetching.md
@@ -1,0 +1,310 @@
+---
+title: "Background Refetching"
+slug: background-refetching
+description: "Background refetching updates stale cache in the background while the UI keeps showing cached data. Which triggers to enable, how staleTime gates them, and how to signal it without a spinner."
+keywords: ["background refetching", "refetchOnWindowFocus", "refetchOnReconnect", "refetchInterval", "isFetching vs isLoading", "stale-while-revalidate"]
+part: "03 · Application Architecture"
+domain: "Data & Server State"
+subcategory: "Server-State Cache"
+difficulty: "Intermediate"
+reading_time_min: 12
+priority: "Critical"
+status: "Published"
+canonical: true
+last_reviewed: "2026-07-24"
+prerequisites:
+  - "Cache Keys & Query Identity"
+  - "Fetch-on-Render vs Render-as-You-Fetch"
+related:
+  - "Cache Keys & Query Identity"
+  - "Staleness & Revalidation"
+  - "Cache Invalidation"
+next:
+  - "Mutation Lifecycle"
+alternatives:
+  - "Staleness & Revalidation"
+  - "Cache Invalidation"
+common_mistakes:
+  - "anti-patterns/README.md#data-server-state"
+  - "#common-mistakes"
+frameworks: ["react"]
+references:
+  - { title: "TanStack Query — Important Defaults", url: "https://tanstack.com/query/latest/docs/framework/react/guides/important-defaults" }
+  - { title: "TanStack Query — Window Focus Refetching", url: "https://tanstack.com/query/latest/docs/framework/react/guides/window-focus-refetching" }
+---
+
+# Background Refetching
+
+> Serve the cached value instantly, then quietly check the server behind it. Done right, the user never waits and the data never rots — done wrong, every window switch flashes a spinner or the data never updates at all.
+
+**Part:** [03 · Application Architecture](../) · **Domain:** Data & Server State · **Priority:** Critical · **Difficulty:** Intermediate · **Reading time:** ~12 min
+
+## TL;DR
+
+Background refetching is the *revalidate* half of stale-while-revalidate: when a query is read and its data is stale, the cache returns the cached value immediately and fires a refetch in the background, swapping in the fresh result when it lands. The triggers are event-based — remounting the query, refocusing the window, reconnecting the network — plus an optional polling interval. The critical distinction is `isLoading` (no data yet, must wait) versus `isFetching` (data on screen, a background request is in flight); confuse them and you turn a silent update into a full-page spinner. Whether a trigger actually refetches is gated by `staleTime`: fresh data never refetches, so `staleTime` is the real tuning knob, not the trigger flags.
+
+> **Recommendation:** Keep the default focus/reconnect/mount triggers on, and tune behavior with `staleTime` rather than disabling triggers. Render background refetches with a subtle `isFetching` indicator, never `isLoading`. Reserve `refetchInterval` for data that genuinely changes without user action, and stop it when the tab is hidden.
+
+## At a Glance
+
+| | |
+| --- | --- |
+| **Use when** | Cached data can drift from the server between reads and you want it current without a manual reload. |
+| **Avoid when** | Data is immutable per session, or a strict interval hammers an expensive endpoint for no user benefit. |
+| **Alternatives** | [Staleness & Revalidation](#alternative-approaches) (the policy that gates it); [Cache Invalidation](#alternative-approaches) (event-driven, targeted). |
+| **Primary risk** | Rendering a background refetch as a blocking spinner, or polling that drains battery and rate limits. |
+| **Maturity** | Stable. |
+
+## Prerequisites
+
+- [Cache Keys & Query Identity](./cache-keys-and-query-identity.md) — a refetch targets the exact key whose data is stale.
+- [Fetch-on-Render vs Render-as-You-Fetch](./fetch-on-render-vs-render-as-you-fetch.md) — when the initial request starts, which background refetching extends.
+
+## Overview
+
+*Background refetching* is the cache re-requesting data a component already has, without blocking the render on the result. It is the mechanism behind the "revalidate" in stale-while-revalidate: a read of stale data returns the cached copy synchronously so the UI paints now, and a refetch runs in the background so the copy converges on the server's current value. The user sees data immediately and sees it update a moment later, rather than waiting on a spinner for data they already had a version of.
+
+The behavior is driven by triggers, not timers alone. TanStack Query refetches a query in the background when the query remounts (`refetchOnMount`), when the window regains focus (`refetchOnWindowFocus`), and when the network reconnects (`refetchOnReconnect`) — the events that correlate with "the user came back and might be looking at old data." A `refetchInterval` adds time-based polling on top. Every one of these is gated by `staleTime`: a query still within its `staleTime` is *fresh* and refetches for none of these triggers. That is the boundary to internalize — the triggers decide *when the cache checks staleness*, and `staleTime` decides *whether the check leads to a request*.
+
+## The Problem
+
+A dashboard reads a list of open tickets. The team wants it current, so they see two failure modes and overcorrect between them. First version: every navigation back to the dashboard shows a full-screen loading spinner while the list refetches, even though the previous list is still perfectly renderable — the code branches on `isLoading`, which is true whenever a fetch runs. The dashboard feels slower than a hard refresh.
+
+Reacting to that, the team disables refetching: `refetchOnWindowFocus: false`, a huge `staleTime`. Now the spinner is gone, but a ticket someone closed ten minutes ago still shows as open until a manual reload. They have swung from "refetches too visibly" to "never refetches," and neither is what they wanted. The actual goal — show the cached list instantly, update it quietly in the background — is exactly what background refetching does by default, if `isLoading` versus `isFetching` is respected and `staleTime` is set to a sane window instead of zero or infinity.
+
+## Why It Matters
+
+Server data goes stale the instant it is cached, because another user or process can change it. Background refetching is how a client stays current without making the user pay a latency tax on every view — the difference between an app that feels live and one that shows a stale snapshot until manually reloaded. For any multi-user or long-lived screen, that freshness is a correctness property, not a nicety: acting on data you can see is wrong if the data is quietly out of date.
+
+The cost of getting it wrong runs both directions. Treat every background refetch as a blocking load and the app feels slower the more it caches — the opposite of the intended payoff. Disable refetching to kill the spinner and the app shows stale data confidently. And reach for `refetchInterval` as the freshness tool and you get constant polling that drains mobile batteries, burns API quota, and refetches a hidden tab nobody is watching. The lever that resolves all three is understanding that `staleTime` — not the trigger flags — governs how often the network is actually touched, and that background fetches must render differently from initial loads.
+
+## Mental Model
+
+Picture two clocks per query. `staleTime` decides when data turns from *fresh* to *stale*; `gcTime` (formerly `cacheTime`) decides when an unused query is dropped from memory. Triggers only ever ask one question — "is this query stale?" — and only a *stale* answer produces a background request. Fresh data is served from cache and no network happens, no matter how many times the window is focused.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant C as Cache
+    participant S as Server
+    U->>C: read query (revisit / refocus)
+    alt data is fresh (within staleTime)
+        C-->>U: cached value, no request
+    else data is stale
+        C-->>U: cached value immediately (isFetching = true)
+        C->>S: background refetch
+        S-->>C: fresh data
+        C-->>U: swap in fresh value (isFetching = false)
+    end
+```
+
+The state you render on determines whether this is invisible or jarring. `isLoading` is `true` only when there is **no cached data to show** — the genuine first load. `isFetching` is `true` whenever a request is in flight, including every background refetch over existing data. Branch your full-screen spinner on `isLoading`; branch a small inline "updating" affordance on `isFetching`. This one mapping is the whole difference between a background refetch the user never notices and one that blanks the screen.
+
+## Best Practices
+
+Tune `staleTime`, not the triggers. The instinct on seeing an unwanted refetch is to disable `refetchOnWindowFocus`; the better fix is to set a `staleTime` that matches how fast the data actually changes (seconds for a live feed, minutes for a settings page). With a correct `staleTime`, the default triggers refetch exactly when it is worth it and skip it otherwise.
+
+Render `isFetching` and `isLoading` differently. Show the cached data with a subtle background indicator (a thin progress bar, a dimmed refresh icon) while `isFetching`; reserve the skeleton or full spinner for `isLoading`, when there is truly nothing to show. Never gate the whole view on `isFetching`.
+
+Keep the default focus and reconnect triggers on. "The user switched back to the tab" and "the laptop rejoined Wi-Fi" are precisely the moments cached data is most likely to be stale. Disabling these globally is the common overcorrection; scope any opt-out to the specific queries that warrant it.
+
+Use `refetchInterval` only for data that changes without user action, and pause it when hidden. Polling suits live prices, job status, and notifications — not a profile page. Set `refetchIntervalInBackground: false` (the default) so a hidden tab stops polling, and prefer the longest interval the feature tolerates.
+
+Let the fresh/stale window absorb bursts. Because a fresh query refetches for no trigger, a sensible `staleTime` naturally deduplicates a flurry of focus/mount events — you do not need to hand-throttle refetches. This composes with [request deduplication](./cache-keys-and-query-identity.md) at the key level.
+
+## Trade-offs
+
+Background refetching trades a small amount of extra network and render churn for data that stays current without blocking the user. For volatile, shared data the trade is strongly positive; for static data it is pure overhead you switch off with `staleTime`.
+
+**Advantages**
+
+- The user reads cached data instantly and it self-updates — no latency tax per view.
+- Freshness follows real signals (focus, reconnect, remount) instead of manual reloads.
+- `staleTime` gives one dial to trade freshness against request volume.
+
+**Disadvantages**
+
+- Extra requests and a re-render when fresh data lands; wasteful for immutable data.
+- Easy to mis-render as a blocking spinner, defeating the purpose.
+- `refetchInterval` can drain battery and rate limits if used as the default freshness tool.
+
+| Dimension | Background refetching | Cost / caveat |
+| --- | --- | --- |
+| Performance | Instant paint from cache; update off the critical path | An extra request + re-render per stale read |
+| Complexity | Mostly defaults; one `staleTime` per query | Must split `isFetching` vs `isLoading` in the UI |
+| Maintainability | Freshness policy centralized in query options | Interval polling needs care around visibility |
+| Failure behavior | Keeps showing last-good data if the refetch fails | A silently failing refetch can look "fresh" but isn't |
+
+## Alternative Approaches
+
+Background refetching is the *time/event-triggered* freshness mechanism. Its alternatives address the same "keep the cache current" job from different angles: staleness policy decides *when* a refetch is allowed, and invalidation pushes freshness *reactively* after a known change.
+
+| Approach | Best when | Weakness | See |
+| --- | --- | --- | --- |
+| Background refetching (this article) | Data drifts over time; freshness on revisit/focus | Time/event-based, not tied to a specific change | (this article) |
+| [Staleness & Revalidation](./staleness-and-revalidation.md) | You need to define *when* data counts as stale | A policy, not a trigger — pairs with this | `Staleness & Revalidation · Data & Server State` |
+| [Cache Invalidation](./cache-invalidation.md) | A known event (a mutation) makes data stale *now* | Requires knowing what changed | `Cache Invalidation · Data & Server State` |
+
+## Bad Example
+
+A query whose entire view is gated on `isFetching`, so every background refetch blanks the screen the user was reading.
+
+```tsx
+import { useQuery } from '@tanstack/react-query';
+import { ticketKeys } from './ticket-keys';
+
+// ❌ isFetching is true on EVERY background refetch, not just the first load.
+// Gating the whole view on it means each window refocus throws away the
+// perfectly good cached list and shows a spinner — slower than no cache.
+function TicketList() {
+  const { data, isFetching } = useQuery({
+    queryKey: ticketKeys.list(),
+    queryFn: fetchTickets,
+  });
+
+  if (isFetching) {
+    return <FullPageSpinner />;
+  }
+
+  return <Tickets items={data ?? []} />;
+}
+```
+
+**What goes wrong:** `isFetching` is `true` during background refetches over existing data, so a `refetchOnWindowFocus` (on by default) replaces the visible list with a spinner every time the user tabs back. The cache is working; the render throws its benefit away.
+
+## Good Example
+
+The same query, splitting the genuine first load from background refetches and tuning freshness with `staleTime`.
+
+```tsx
+import { useQuery } from '@tanstack/react-query';
+import { ticketKeys } from './ticket-keys';
+
+interface Ticket {
+  id: string;
+  subject: string;
+  status: 'open' | 'closed';
+}
+
+async function fetchTickets({ signal }: { signal: AbortSignal }): Promise<Ticket[]> {
+  const response = await fetch('/api/tickets', { signal });
+  if (!response.ok) {
+    throw new Error(`Failed to load tickets (${response.status})`);
+  }
+  return (await response.json()) as Ticket[];
+}
+
+function TicketList() {
+  const { data, isLoading, isError, error, isFetching } = useQuery({
+    queryKey: ticketKeys.list(),
+    queryFn: fetchTickets,
+    // Treat data as fresh for 30s: focus/mount within that window won't refetch,
+    // absorbing bursts. After 30s a revisit refetches in the background.
+    staleTime: 30_000,
+  });
+
+  // ✅ Only the true first load (no cached data) shows the skeleton.
+  if (isLoading) {
+    return <TicketsSkeleton />;
+  }
+
+  if (isError) {
+    return <p role="alert">Couldn’t load tickets: {error.message}</p>;
+  }
+
+  return (
+    <section aria-busy={isFetching}>
+      {/* ✅ Background refetch is a quiet affordance over the visible list. */}
+      {isFetching && <span className="refreshing" aria-live="polite">Updating…</span>}
+      <Tickets items={data} />
+    </section>
+  );
+}
+```
+
+**Why it's better:** The skeleton is gated on `isLoading`, so it appears once, on the real first load. Background refetches keep the list on screen and surface only a small, `aria-live` "Updating…" hint. A 30-second `staleTime` means routine refocus doesn't refetch at all, cutting request volume without any trigger disabled.
+
+## Production Example
+
+A live order-status view that polls while visible, backs off when the tab is hidden, and stops once the order reaches a terminal state — the disciplined use of `refetchInterval`.
+
+```tsx
+import { useQuery } from '@tanstack/react-query';
+import { orderKeys } from './order-keys';
+
+interface Order {
+  id: string;
+  status: 'pending' | 'preparing' | 'out_for_delivery' | 'delivered' | 'cancelled';
+}
+
+const TERMINAL: ReadonlySet<Order['status']> = new Set(['delivered', 'cancelled']);
+
+async function fetchOrder(
+  id: string,
+  signal: AbortSignal,
+): Promise<Order> {
+  const response = await fetch(`/api/orders/${id}`, { signal });
+  if (!response.ok) {
+    throw new Error(`Failed to load order (${response.status})`);
+  }
+  return (await response.json()) as Order;
+}
+
+export function useOrderStatus(orderId: string) {
+  return useQuery({
+    queryKey: orderKeys.detail(orderId),
+    queryFn: ({ signal }) => fetchOrder(orderId, signal),
+    // Poll every 5s — but only while the order is still in flight.
+    refetchInterval: (query) =>
+      query.state.data && TERMINAL.has(query.state.data.status) ? false : 5_000,
+    // Default: don't poll a hidden tab. Saves battery and quota.
+    refetchIntervalInBackground: false,
+    staleTime: 0, // status is volatile; treat every read as stale
+  });
+}
+```
+
+## Common Mistakes
+
+See the [Data & Server State anti-patterns](../../../anti-patterns/README.md#data-server-state) for the domain catalog. Concept-specific:
+
+### Mistake: Rendering a background refetch as a full-page spinner
+
+- **Symptom:** The whole view is gated on `isFetching`; every focus/remount blanks the screen.
+- **Why it fails:** `isFetching` covers background refetches over existing data, not just the first load, so cached data is thrown away on each revisit.
+- **Fix:** Gate the skeleton on `isLoading`; show only a small inline indicator while `isFetching`.
+
+### Mistake: Disabling refetch triggers instead of setting `staleTime`
+
+- **Symptom:** `refetchOnWindowFocus: false` (or `staleTime: Infinity`) applied broadly to stop unwanted requests.
+- **Why it fails:** It kills freshness entirely; data goes stale and only a manual reload fixes it.
+- **Fix:** Leave the triggers on and set a `staleTime` that matches the data's real change rate.
+
+### Mistake: Using `refetchInterval` as the default freshness tool
+
+- **Symptom:** Many queries poll on a timer, including on hidden tabs.
+- **Why it fails:** Constant polling drains battery and rate limits and refetches data nobody is viewing.
+- **Fix:** Prefer event triggers + `staleTime`; reserve intervals for genuinely live data and keep `refetchIntervalInBackground: false`.
+
+## Checklist
+
+- [ ] The first-load skeleton is gated on `isLoading`, not `isFetching`.
+- [ ] Background refetches render as a subtle, `aria-live` affordance over existing data.
+- [ ] `staleTime` is set per query to its real change rate — not left at `0` everywhere or set to `Infinity` to silence refetches.
+- [ ] Default focus/reconnect/mount triggers stay on unless a specific query justifies opting out.
+- [ ] `refetchInterval` is used only for live data, stops at terminal states, and does not poll hidden tabs.
+
+## Related Articles
+
+- [Staleness & Revalidation](./staleness-and-revalidation.md) — the policy that decides when a refetch is allowed to fire.
+- [Cache Invalidation](./cache-invalidation.md) — pushing freshness reactively after a known change.
+- [Cache Keys & Query Identity](./cache-keys-and-query-identity.md) — the identity a refetch targets and deduplicates on.
+
+## Related Examples
+
+- [Stale-time configuration](../../../examples/stale-time-configuration.ts) — the dial that gates whether a background trigger actually refetches.
+
+## References
+
+- [TanStack Query — Important Defaults](https://tanstack.com/query/latest/docs/framework/react/guides/important-defaults) — default `staleTime`, and the mount/focus/reconnect refetch triggers.
+- [TanStack Query — Window Focus Refetching](https://tanstack.com/query/latest/docs/framework/react/guides/window-focus-refetching) — `refetchOnWindowFocus` and how to tune it.

--- a/docs/03-application-architecture/data-server-state/cache-invalidation.md
+++ b/docs/03-application-architecture/data-server-state/cache-invalidation.md
@@ -137,7 +137,7 @@ Invalidation is the *event-driven* way to keep data fresh; its alternatives are 
 | --- | --- | --- | --- |
 | Invalidation (this article) | A discrete event changed the data | Must know the affected keys | (this article) |
 | [Staleness & Revalidation](./staleness-and-revalidation.md) | Data changes on its own over time | Fails silently if `staleTime` is too high | `Staleness & Revalidation` |
-| Background refetching | Near-real-time freshness needed | Polling cost | *Background Refetching* (planned — see the [domain index](./README.md)) |
+| [Background refetching](./background-refetching.md) | Near-real-time freshness needed | Polling cost | `Background Refetching` |
 
 ## Bad Example
 

--- a/docs/03-application-architecture/data-server-state/cache-keys-and-query-identity.md
+++ b/docs/03-application-architecture/data-server-state/cache-keys-and-query-identity.md
@@ -261,7 +261,7 @@ See the [Data & Server State anti-patterns](../../../anti-patterns/README.md#dat
 
 - [Cache Invalidation](./cache-invalidation.md) — how prefix keys let one mutation refresh a subtree.
 - [Staleness & Revalidation](./staleness-and-revalidation.md) — what a keyed entry does between reads.
-- *Background Refetching* is a sibling here (planned — see the [Data & Server State index](./README.md)).
+- [Background Refetching](./background-refetching.md) — interval and focus revalidation for the same keys.
 
 ## Related Recipes
 

--- a/docs/03-application-architecture/data-server-state/mutation-lifecycle.md
+++ b/docs/03-application-architecture/data-server-state/mutation-lifecycle.md
@@ -135,7 +135,7 @@ Keep `mutationFn` pure and typed at the boundary. It takes typed `variables`, pe
 
 ## Alternative Approaches
 
-The lifecycle itself has no substitute — every write passes through these states whether or not you model them. What varies is the *cache-update strategy* layered on top: invalidate-after-success (simple, a round trip of latency) versus optimistic update (instant, needs rollback). Those are covered in [Optimistic Updates](./optimistic-updates.md) and *Rollback & Conflict Resolution* (planned). `alternatives: []` here because there is no competing way to *be* a mutation.
+The lifecycle itself has no substitute — every write passes through these states whether or not you model them. What varies is the *cache-update strategy* layered on top: invalidate-after-success (simple, a round trip of latency) versus optimistic update (instant, needs rollback). Those are covered in [Optimistic Updates](./optimistic-updates.md) and [Rollback & Conflict Resolution](./rollback-and-conflict-resolution.md). `alternatives: []` here because there is no competing way to *be* a mutation.
 
 ## Bad Example
 
@@ -297,7 +297,7 @@ See the [Data & Server State anti-patterns](../../../anti-patterns/README.md#dat
 
 - [Optimistic Updates](./optimistic-updates.md) — using `onMutate`/`onError` to apply and roll back a write instantly.
 - [Cache Invalidation](./cache-invalidation.md) — what to do in `onSettled`.
-- *Rollback & Conflict Resolution* extends the error path (planned — see the [Data & Server State index](./README.md)).
+- [Rollback & Conflict Resolution](./rollback-and-conflict-resolution.md) — extends the error path.
 
 ## Related Recipes
 

--- a/docs/03-application-architecture/data-server-state/optimistic-updates.md
+++ b/docs/03-application-architecture/data-server-state/optimistic-updates.md
@@ -144,7 +144,7 @@ The alternative is the plain mutation flow — show pending, wait, invalidate �
 | --- | --- | --- | --- |
 | Optimistic update (this article) | Frequent, low-stakes, near-always-successful writes | Needs hand-built rollback | (this article) |
 | Pending-then-invalidate | Rare or high-stakes writes; simplicity wins | User waits a round trip | [Mutation Lifecycle](./mutation-lifecycle.md) |
-| Rollback & conflict resolution | Concurrent edits can conflict | More logic to merge/resolve | *Rollback & Conflict Resolution* (planned — see the [domain index](./README.md)) |
+| [Rollback & conflict resolution](./rollback-and-conflict-resolution.md) | Concurrent edits can conflict | More logic to merge/resolve | `Rollback & Conflict Resolution` |
 
 ## Bad Example
 
@@ -311,7 +311,7 @@ See the [Data & Server State anti-patterns](../../../anti-patterns/README.md#dat
 
 - [Mutation Lifecycle](./mutation-lifecycle.md) — the callbacks optimism hooks into.
 - [Cache Invalidation](./cache-invalidation.md) — the reconciliation step in `onSettled`.
-- *Rollback & Conflict Resolution* handles concurrent-edit conflicts (planned — see the [Data & Server State index](./README.md)).
+- [Rollback & Conflict Resolution](./rollback-and-conflict-resolution.md) — handles concurrent-edit conflicts.
 
 ## Related Recipes
 

--- a/docs/03-application-architecture/data-server-state/rollback-and-conflict-resolution.md
+++ b/docs/03-application-architecture/data-server-state/rollback-and-conflict-resolution.md
@@ -1,0 +1,362 @@
+---
+title: "Rollback & Conflict Resolution"
+slug: rollback-and-conflict-resolution
+description: "When an optimistic write fails or two writes collide, a snapshot restore isn't enough. How to roll back safely under concurrency and resolve server conflicts with versioned writes."
+keywords: ["rollback", "conflict resolution", "optimistic concurrency", "409 conflict", "If-Match ETag", "concurrent mutations", "last write wins"]
+part: "03 · Application Architecture"
+domain: "Data & Server State"
+subcategory: "Mutations"
+difficulty: "Intermediate"
+reading_time_min: 15
+priority: "Critical"
+status: "Published"
+canonical: true
+last_reviewed: "2026-07-24"
+prerequisites:
+  - "Mutation Lifecycle"
+  - "Cache Keys & Query Identity"
+related:
+  - "Mutation Lifecycle"
+  - "Optimistic Updates"
+next:
+  - "Pagination"
+alternatives:
+  - "Optimistic Updates"
+common_mistakes:
+  - "anti-patterns/README.md#data-server-state"
+  - "#common-mistakes"
+frameworks: ["react"]
+references:
+  - { title: "TanStack Query — Optimistic Updates", url: "https://tanstack.com/query/latest/docs/framework/react/guides/optimistic-updates" }
+  - { title: "MDN — 409 Conflict", url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409" }
+  - { title: "MDN — If-Match", url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match" }
+---
+
+# Rollback & Conflict Resolution
+
+> A snapshot restore undoes *your* failed write. It says nothing about the write that landed on the server between your read and your submit — and restoring a stale snapshot on top of a concurrent change is how optimistic UIs lose data.
+
+**Part:** [03 · Application Architecture](../) · **Domain:** Data & Server State · **Priority:** Critical · **Difficulty:** Intermediate · **Reading time:** ~15 min
+
+## TL;DR
+
+The simple rollback from [optimistic updates](./optimistic-updates.md) — snapshot in `onMutate`, restore in `onError` — is correct only when writes don't overlap. Under concurrency it breaks two ways: two optimistic mutations on the same entity produce two snapshots, and restoring the older one silently reverts the newer one; and a value that changed on the server between your read and your write is a *conflict*, not a transient error, so blindly retrying or restoring corrupts state. Robust handling means serializing mutations that touch the same key, distinguishing a conflict (HTTP 409, or a version mismatch) from a retryable failure, and choosing a resolution — last-write-wins, merge, or ask the user — deliberately rather than by accident. Optimistic concurrency with a version or `ETag` is what lets the server *detect* the conflict in the first place.
+
+> **Recommendation:** For overlapping writes to one entity, serialize them with a mutation `scope` and reconcile from server truth in `onSettled` rather than trusting a stale snapshot. Send a version/`If-Match` with every write so the server can reject conflicts with 409; on 409, resolve explicitly (refetch and re-apply, merge, or prompt) — never auto-retry a conflict as if it were a network blip.
+
+## At a Glance
+
+| | |
+| --- | --- |
+| **Use when** | Optimistic or concurrent writes hit the same record, or multiple clients can edit the same data. |
+| **Avoid when** | Writes are serial, single-client, and can't collide — a plain snapshot rollback suffices. |
+| **Alternatives** | [Optimistic Updates](#alternative-approaches) with simple rollback (correct only without overlap). |
+| **Primary risk** | Restoring a stale snapshot over a newer change, or retrying a conflict and clobbering the server. |
+| **Maturity** | Stable (patterns); the resolution policy is application-specific. |
+
+## Prerequisites
+
+- [Mutation Lifecycle](./mutation-lifecycle.md) — `onMutate`/`onError`/`onSettled` and mutation `scope` are the hook points.
+- [Cache Keys & Query Identity](./cache-keys-and-query-identity.md) — rollback and reconciliation operate per exact key.
+
+## Overview
+
+*Rollback* is undoing a change the server didn't accept; *conflict resolution* is deciding what to do when the server rejects it because the data changed underneath you. The two are distinct. A rollback restores a known-previous state; conflict resolution reconciles two divergent states — yours and the server's — into one. The simple optimistic pattern conflates them by assuming every failure is "the write didn't happen, put it back." That assumption holds for a dropped connection. It fails when the write *did* touch a record another actor already changed.
+
+The two hard cases are concurrency and staleness. **Concurrent client writes:** two mutations on the same entity run before either settles, each captured its own `previous` snapshot, and whichever errors last restores *its* snapshot — which predates the other mutation, reverting it. **Stale write / server conflict:** you loaded a record at version 3, edited it, and submitted; meanwhile it became version 4. A last-write-wins server silently overwrites version 4; a conflict-aware server rejects your write with `409 Conflict` because your `If-Match` no longer matches. Detecting that requires *optimistic concurrency* — sending the version you based your edit on — and resolving it requires an explicit choice, because "correct" depends on the data.
+
+## The Problem
+
+A shared kanban board lets two people drag cards. Alice moves card #7 to "Done" and, a second later before her request settles, moves card #12. Both mutations optimistically write the cache; each snapshots the board first. Card #7's request fails on a flaky connection and its `onError` restores *its* snapshot — the board as it was **before card #12 moved**. Card #12 jumps back to its old column on screen even though its own request succeeded. The user watched a change they made, that worked, get undone by an unrelated failure.
+
+Now the multi-client case. Bob loads card #7's description (version 3) and starts editing. Alice edits the same description and saves (now version 4). Bob saves. A naive server takes Bob's write and overwrites Alice's — her paragraph vanishes with no error anywhere. Nobody did anything "wrong"; the system simply had no way to notice that Bob's edit was based on a version that no longer existed. Both failures come from the same root: rollback and retry logic that assumes writes are isolated, when they are not.
+
+## Why It Matters
+
+Optimistic UIs make concurrency visible. The moment you write to the cache before the server confirms, you have two sources of truth in flight, and the rules for merging them back are yours to define. Get them wrong and the bug class is the worst kind — silent data loss and phantom reverts that appear only under timing and only for some users, impossible to reproduce on a developer's fast, single-tab connection. These are the failures that erode trust in an app: "it lost my edit," "my change came back."
+
+The stakes rise with every additional editor. A single-user app can often get away with last-write-wins because there is no one to conflict with. A collaborative tool cannot: without conflict detection, concurrent edits quietly destroy each other, and users learn not to trust the app with anything important. Optimistic concurrency (a version or `ETag` per record) is the cheapest mechanism that turns invisible data loss into a detectable, resolvable event — and detection is the prerequisite for any resolution policy at all. Deciding the policy deliberately, rather than defaulting to whichever write happens to land last, is what separates a robust mutation layer from one that works only in the demo.
+
+## Mental Model
+
+Think of each optimistic write as a bet placed against a specific prior state — the version you read. Resolving the bet has three possible outcomes, not two: it won (server accepted), it lost transiently (network/5xx — safe to retry the *same* bet), or the table changed (conflict — the bet is void and you must re-read before betting again). Treating outcome three as outcome two is the core error.
+
+```mermaid
+flowchart TD
+    W[Optimistic write, based on version N] --> R{Server response}
+    R -->|2xx accepted| OK[Reconcile: invalidate, take server truth]
+    R -->|5xx / network| T[Transient: retry same write]
+    R -->|409 / version mismatch| C{Conflict policy}
+    C -->|last-write-wins| F[Force with server's current version]
+    C -->|merge| M[Combine changes, resubmit]
+    C -->|manual| U[Refetch + surface both to the user]
+```
+
+For concurrency *within* one client, the fix is to stop the overlap: give mutations that touch the same entity a shared `scope` so the cache runs them one at a time, and lean on `onSettled` invalidation — server truth — rather than a possibly-stale snapshot to land the final state. For conflicts *across* clients, the fix is detection first (send the version), then a policy. The snapshot is still useful for the transient case; it is simply not sufficient on its own.
+
+## Best Practices
+
+Serialize mutations that share an entity with `scope`. TanStack Query runs mutations with the same `scope.id` sequentially instead of in parallel, so two writes to card #7 don't interleave and their snapshots don't cross. This removes the "unrelated failure reverts my other change" class outright.
+
+Reconcile from the server in `onSettled`, not only from the snapshot. The snapshot restores the transient case, but the authoritative final state is the server's. Invalidate the key on settle so the cache converges on server truth after either outcome — this also corrects a restored snapshot that has itself gone stale.
+
+Send the version you edited with every write. Include a `version` field or an `If-Match: <etag>` header carrying the value you based the edit on. This is what lets the server return `409 Conflict` instead of silently overwriting. Without it, conflict *detection* is impossible and every resolution strategy is moot.
+
+Distinguish a conflict from a transient failure before reacting. A 409 (or a typed conflict body) means the data moved — do not auto-retry it; that just re-submits a stale write. A network error or 5xx is retryable with backoff. Branch `onError` on the failure kind; never funnel both into "restore and retry."
+
+Choose the resolution policy per data, and make manual resolution legible. Last-write-wins is fine for low-stakes fields (a toggle); merge suits additive data (tags, a comment list); genuinely conflicting prose needs the user. When you surface a conflict, refetch the current server value and present it — never discard the user's unsaved edit to make the conflict "go away."
+
+## Trade-offs
+
+Conflict-aware rollback costs a version field, sequential mutations, and a resolution policy you must design. In exchange you get correctness under concurrency that a plain snapshot rollback cannot provide. For single-client serial writes it is over-engineering; for anything collaborative it is the floor.
+
+**Advantages**
+
+- Concurrent writes to one entity stop reverting each other.
+- Conflicts become detectable events instead of silent data loss.
+- Reconciling from server truth self-heals stale snapshots.
+
+**Disadvantages**
+
+- Requires server support (a version/`ETag` and 409 semantics).
+- Serializing mutations reduces write parallelism for the same entity.
+- A real resolution policy — especially merge or manual — is genuine design work.
+
+| Dimension | Conflict-aware rollback | Cost / caveat |
+| --- | --- | --- |
+| Performance | Same-entity writes serialize; unrelated ones stay parallel | A queued write waits for the one ahead |
+| Complexity | Version field + branch on conflict vs transient | More states than snapshot-restore |
+| Maintainability | Policy centralized per mutation | Merge/manual logic is application-specific |
+| Failure behavior | Detects conflicts; reconciles to server truth | Needs a chosen policy or it degrades to last-write-wins |
+
+## Alternative Approaches
+
+The alternative is the plain optimistic pattern: snapshot and restore, no version, no conflict handling. It is correct and simpler — until writes overlap or multiple clients edit the same data, at which point it silently loses changes.
+
+| Approach | Best when | Weakness | See |
+| --- | --- | --- | --- |
+| Conflict-aware rollback (this article) | Concurrent or multi-client writes to shared records | Needs server versioning + a resolution policy | (this article) |
+| [Optimistic Updates](./optimistic-updates.md) with snapshot rollback | Serial, single-client writes that can't collide | Reverts concurrent changes; can't detect conflicts | `Optimistic Updates · Data & Server State` |
+| Pessimistic write (wait, then invalidate) | Correctness dominates and latency is acceptable | User waits a full round trip | [Mutation Lifecycle](./mutation-lifecycle.md) |
+
+## Bad Example
+
+Two optimistic writes to the same entity, each with its own snapshot, running in parallel — the older snapshot reverts the newer change on any failure.
+
+```tsx
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { cardKeys } from './card-keys';
+
+// ❌ No scope, so writes to the same board run in parallel. On error, this
+// restores THIS mutation's snapshot — which predates any other in-flight
+// write — silently reverting unrelated changes the user already made.
+function useMoveCard() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: moveCard,
+    onMutate: async (move: CardMove) => {
+      await queryClient.cancelQueries({ queryKey: cardKeys.board() });
+      const previous = queryClient.getQueryData<Board>(cardKeys.board());
+      queryClient.setQueryData<Board>(cardKeys.board(), (b) => applyMove(b, move));
+      return { previous };
+    },
+    onError: (_error, _move, context) => {
+      // Restores the whole board to a stale snapshot, clobbering other moves.
+      queryClient.setQueryData(cardKeys.board(), context?.previous);
+    },
+  });
+}
+```
+
+**What goes wrong:** With no serialization, moving card #7 and card #12 in quick succession snapshots the board twice. If #7's request fails, its `onError` restores the board as it was before #12 moved, reverting a change that succeeded. And because the write carries no version, a stale edit from another client is accepted with no conflict at all.
+
+## Good Example
+
+Same-entity writes serialized with `scope`, the failure branched into conflict versus transient, and reconciliation from server truth on settle.
+
+```tsx
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { cardKeys } from './card-keys';
+
+interface Board {
+  id: string;
+  version: number;
+  cards: Card[];
+}
+
+class ConflictError extends Error {
+  constructor(readonly serverVersion: number) {
+    super('Board changed since it was loaded');
+    this.name = 'ConflictError';
+  }
+}
+
+async function moveCard(move: CardMove & { baseVersion: number }): Promise<Board> {
+  const response = await fetch(`/api/boards/${move.boardId}/move`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      // Optimistic concurrency: the server rejects if this no longer matches.
+      'if-match': `"${move.baseVersion}"`,
+    },
+    body: JSON.stringify(move),
+  });
+  if (response.status === 409) {
+    const body = (await response.json()) as { version: number };
+    throw new ConflictError(body.version);
+  }
+  if (!response.ok) {
+    throw new Error(`Move failed (${response.status})`);
+  }
+  return (await response.json()) as Board;
+}
+
+function useMoveCard() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: moveCard,
+    // ✅ Serialize every write to this board; snapshots can't cross.
+    scope: { id: 'board-mutations' },
+    onMutate: async (move) => {
+      await queryClient.cancelQueries({ queryKey: cardKeys.board() });
+      const previous = queryClient.getQueryData<Board>(cardKeys.board());
+      queryClient.setQueryData<Board>(cardKeys.board(), (b) =>
+        b ? applyMove(b, move) : b,
+      );
+      return { previous };
+    },
+    onError: (error, _move, context) => {
+      // ✅ A conflict is NOT retryable: refetch server truth and let the user
+      // re-apply, instead of restoring a snapshot that's now wrong.
+      if (error instanceof ConflictError) {
+        void queryClient.invalidateQueries({ queryKey: cardKeys.board() });
+        return;
+      }
+      // Transient failure: the snapshot is the correct previous state.
+      if (context?.previous) {
+        queryClient.setQueryData(cardKeys.board(), context.previous);
+      }
+    },
+    onSettled: () => {
+      // ✅ Land on the server's authoritative version after either outcome.
+      void queryClient.invalidateQueries({ queryKey: cardKeys.board() });
+    },
+  });
+}
+```
+
+**Why it's better:** `scope` serializes writes so overlapping moves can't revert one another. The write sends `If-Match`, so the server detects a stale edit and returns 409, which `onError` treats as a conflict — refetch, don't retry — distinct from a transient failure where the snapshot is valid. `onSettled` reconciles to the server's real version regardless.
+
+## Production Example
+
+A field edit with a versioned write and a manual-merge resolution: on conflict, the current server value is fetched and both versions are handed to a resolver so the user's unsaved edit is never discarded.
+
+```tsx
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { docKeys } from './doc-keys';
+
+interface Doc {
+  id: string;
+  version: number;
+  body: string;
+}
+
+interface EditInput {
+  id: string;
+  body: string;
+  baseVersion: number;
+}
+
+class DocConflict extends Error {
+  constructor(readonly current: Doc, readonly attempted: string) {
+    super('Document changed during edit');
+    this.name = 'DocConflict';
+  }
+}
+
+async function saveDoc(input: EditInput): Promise<Doc> {
+  const response = await fetch(`/api/docs/${input.id}`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json', 'if-match': `"${input.baseVersion}"` },
+    body: JSON.stringify({ body: input.body }),
+  });
+  if (response.status === 409) {
+    const current = (await response.json()) as Doc;
+    throw new DocConflict(current, input.body);
+  }
+  if (!response.ok) {
+    throw new Error(`Save failed (${response.status})`);
+  }
+  return (await response.json()) as Doc;
+}
+
+export function useSaveDoc(onConflict: (current: Doc, mine: string) => void) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: saveDoc,
+    scope: { id: 'doc-save' },
+    onError: (error) => {
+      if (error instanceof DocConflict) {
+        // Surface both sides; the user's text stays put until they choose.
+        onConflict(error.current, error.attempted);
+      }
+      // Transient errors fall through to React Query's retry/backoff.
+    },
+    onSuccess: (saved) => {
+      queryClient.setQueryData(docKeys.detail(saved.id), saved);
+    },
+  });
+}
+```
+
+## Common Mistakes
+
+See the [Data & Server State anti-patterns](../../../anti-patterns/README.md#data-server-state) for the domain catalog. Concept-specific:
+
+### Mistake: One snapshot restoring over a concurrent write
+
+- **Symptom:** An unrelated failed mutation reverts a change the user already made successfully.
+- **Why it fails:** Parallel writes to one entity each snapshot independently; the older snapshot predates the newer change.
+- **Fix:** Serialize same-entity mutations with a shared `scope`, and reconcile from server truth in `onSettled`.
+
+### Mistake: Treating a conflict as a transient error
+
+- **Symptom:** A 409 (or version mismatch) is auto-retried like a network failure.
+- **Why it fails:** Retrying re-submits a write based on a version that no longer exists; it either fails again or forces a last-write-wins overwrite.
+- **Fix:** Branch on the failure kind — refetch and resolve on conflict; retry only transient failures.
+
+### Mistake: Writing without a version (no conflict detection)
+
+- **Symptom:** Concurrent edits silently overwrite each other with no error surfaced.
+- **Why it fails:** With no `If-Match`/version, the server can't tell a stale write from a fresh one.
+- **Fix:** Send the base version with every write and have the server reject mismatches with 409.
+
+## Checklist
+
+- [ ] Mutations that touch the same entity share a `scope` so they can't interleave.
+- [ ] Every write carries the version it was based on (`If-Match` or a `version` field).
+- [ ] `onError` distinguishes a conflict (409/version mismatch) from a retryable failure.
+- [ ] Conflicts refetch server truth; the user's unsaved edit is preserved, not discarded.
+- [ ] `onSettled` invalidates so the cache converges on the server's authoritative value.
+
+## Related Articles
+
+- [Optimistic Updates](./optimistic-updates.md) — the snapshot-and-rollback this article hardens for concurrency.
+- [Mutation Lifecycle](./mutation-lifecycle.md) — the `onMutate`/`onError`/`onSettled` and `scope` hooks used here.
+- [Cache Invalidation](./cache-invalidation.md) — the reconciliation step that lands server truth after a conflict.
+
+## Related Recipes
+
+- [Optimistic list mutation with rollback](../../../recipes/optimistic-list-mutation.md) — the snapshot-and-rollback shape this article hardens for concurrency.
+
+## Related Examples
+
+- [Optimistic update with rollback](../../../examples/optimistic-update-with-rollback.tsx) — the cancel/snapshot/restore baseline the conflict branch extends.
+
+## References
+
+- [TanStack Query — Optimistic Updates](https://tanstack.com/query/latest/docs/framework/react/guides/optimistic-updates) — snapshot, rollback, and `onSettled` reconciliation.
+- [MDN — 409 Conflict](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409) — the status for a request that conflicts with the resource's current state.
+- [MDN — If-Match](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match) — conditional requests for optimistic concurrency.

--- a/docs/03-application-architecture/data-server-state/staleness-and-revalidation.md
+++ b/docs/03-application-architecture/data-server-state/staleness-and-revalidation.md
@@ -138,7 +138,7 @@ Staleness is the *time-driven* half of keeping data current; its true alternativ
 | --- | --- | --- | --- |
 | `staleTime` (this article) | Data changes on its own at a knowable rate | Wrong value fails silently | (this article) |
 | [Cache Invalidation](./cache-invalidation.md) | Data changes because of a user action | Requires knowing which keys a change affects | `Cache Invalidation` |
-| Background refetching (interval/focus) | Near-real-time freshness needed | Polling cost; battery and bandwidth | *Background Refetching* (planned — see the [domain index](./README.md)) |
+| [Background refetching (interval/focus)](./background-refetching.md) | Near-real-time freshness needed | Polling cost; battery and bandwidth | `Background Refetching` |
 
 ## Bad Example
 
@@ -262,7 +262,7 @@ See the [Data & Server State anti-patterns](../../../anti-patterns/README.md#dat
 
 - [Cache Invalidation](./cache-invalidation.md) — the event-driven counterpart to time-driven staleness.
 - [Cache Keys & Query Identity](./cache-keys-and-query-identity.md) — staleness is tracked per key.
-- *Background Refetching* extends this to interval and focus revalidation (planned — see the [Data & Server State index](./README.md)).
+- [Background Refetching](./background-refetching.md) — extends this to interval and focus revalidation.
 
 ## Related Recipes
 


### PR DESCRIPTION
…flict Resolution

Publish two peer-reviewed articles that complete the Server-State Cache and Mutations subcategories, matching their existing graph.json nodes:

- Background Refetching: stale-while-revalidate triggers, isFetching vs isLoading, staleTime gating, disciplined refetchInterval.
- Rollback & Conflict Resolution: concurrency-safe rollback via mutation scope, optimistic concurrency (If-Match/409), conflict-vs-transient.

Upgrade prior 'planned' prose references in optimistic-updates, mutation-lifecycle, cache-invalidation, staleness-and-revalidation, and cache-keys to real links, and add both to the domain README.

<!--
Thanks for contributing to Frontend Engineering!
Fill out this template completely. PRs with an incomplete template may be closed until updated.
Read CONTRIBUTING.md first: ../blob/main/CONTRIBUTING.md
-->

## Summary

<!-- What does this PR change, and why? One or two sentences. -->

Closes #

## Type of change

- [ ] New article
- [ ] Improvement to an existing article
- [ ] Anti-pattern
- [ ] Example / recipe
- [ ] Fix (typo, broken link, formatting)
- [ ] Structure / tooling / workflow
- [ ] Other:

## Affected area

<!-- Which Part/Domain does this touch? e.g. docs/03-application-architecture/state-management -->

Path(s):

## Author checklist

- [ ] I read [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md).
- [ ] Content follows [`templates/article-template.md`](../blob/main/templates/article-template.md) (for articles); no sections removed.
- [ ] Frontmatter and the domain's `graph.json` entry are updated and consistent.
- [ ] Includes a realistic **Bad Example** and a production-ready **Good Example** (for articles).
- [ ] Trade-offs are stated honestly; the recommendation follows from them.
- [ ] File placement and `kebab-case` naming follow the conventions.
- [ ] Internal links use relative paths and resolve.
- [ ] Content is original; sources are cited in References.
- [ ] Automated checks (lint, links, spelling, frontmatter) pass locally where possible.

## Reviewer notes

<!-- Anything reviewers should focus on, open questions, or decisions you want a second opinion on. -->
