### PR TITLE
docs: add performance engineering guides

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -29,7 +29,8 @@
     "preconnected", "prereqs", "recomputations", "rollouts", "strawman", "strawmen",
     "unfocusable", "unrepresentable", "unsanitized", "unsourced", "userbase", "versionable",
     "Clickjacking", "Metaprogramming", "Overcorrecting", "Subresource", "Unshareable", "unreviewed",
-    "Anson", "endgroup", "lycheeverse", "nullglob", "shopt"
+    "Anson", "endgroup", "lycheeverse", "nullglob", "shopt",
+    "contentful", "janky", "unthrottled", "prerender", "prerendering", "overcorrects"
   ],
   "ignorePaths": [
     "_to_delete/**",

--- a/docs/05-reliability-quality/performance/code-splitting.md
+++ b/docs/05-reliability-quality/performance/code-splitting.md
@@ -142,8 +142,8 @@ Code splitting is one of several loading-performance levers, and the best result
 | --- | --- | --- | --- |
 | Code splitting (this article) | Heavy JS most users don't need at first paint | Adds requests and loading states | (this article) |
 | [Resource Prefetch & Preload](./resource-prefetch-and-preload.md) | You know the next resource and want to hide its request | Prefetching too much wastes bandwidth | `Resource Prefetch & Preload` |
-| [Critical CSS & Above-the-Fold](./critical-css-and-above-the-fold.md) | Render-blocking CSS, not JS, is delaying first paint | Inlining critical CSS complicates the build | `Critical CSS & Above-the-Fold` |
-| [Font & Asset Loading Strategy](./font-and-asset-loading-strategy.md) | Fonts and static assets dominate the loading budget | Doesn't address script cost | `Font & Asset Loading Strategy` |
+| Critical CSS & Above-the-Fold | Render-blocking CSS, not JS, is delaying first paint | Inlining critical CSS complicates the build | `Critical CSS & Above-the-Fold` (planned) |
+| Font & Asset Loading Strategy | Fonts and static assets dominate the loading budget | Doesn't address script cost | `Font & Asset Loading Strategy` (planned) |
 
 ## Bad Example
 
@@ -280,7 +280,7 @@ See the [Performance Engineering anti-patterns](../../../anti-patterns/README.md
 
 - [The Critical Rendering Path](./the-critical-rendering-path.md) — where render-blocking JavaScript sits and why shrinking it matters.
 - [Resource Prefetch & Preload](./resource-prefetch-and-preload.md) — how to hide a split chunk's request behind user intent.
-- [Bundle Size Optimization](./bundle-size-optimization.md) — tree-shaking and dependency trimming that pair with splitting.
+- Bundle Size Optimization (planned) — tree-shaking and dependency trimming that pair with splitting.
 - [Core Web Vitals (LCP, INP, CLS)](./core-web-vitals-lcp-inp-cls.md) — the metrics oversized bundles degrade.
 
 ## References

--- a/docs/05-reliability-quality/performance/core-web-vitals-lcp-inp-cls.md
+++ b/docs/05-reliability-quality/performance/core-web-vitals-lcp-inp-cls.md
@@ -62,9 +62,9 @@ Core Web Vitals are three metrics Google standardized to measure user-perceived 
 
 ## Prerequisites
 
-- [Process & Thread Architecture](../../../00-foundations/web-platform/process-and-thread-architecture.md) (`· The Web Platform`) — INP is about the main thread's ability to paint after input.
-- [Parsing & Bytecode](../../../00-foundations/runtime-execution/parsing-and-bytecode.md) (`· Runtime & Execution`) — script parse and compile time is a large part of LCP and INP.
-- [HTTP/1.1 Semantics](../../../00-foundations/networking-protocols/http-1-1-semantics.md) (`· Networking & Protocols`) — resource delivery latency sets the floor for LCP.
+- Process & Thread Architecture (`· The Web Platform`) — INP is about the main thread's ability to paint after input.
+- Parsing & Bytecode (`· Runtime & Execution`) — script parse and compile time is a large part of LCP and INP.
+- HTTP/1.1 Semantics (`· Networking & Protocols`) — resource delivery latency sets the floor for LCP.
 
 ## Overview
 
@@ -151,8 +151,8 @@ There is no substitute for Core Web Vitals as *the* cross-web, field-measured, r
 | Approach | Best when | Weakness | See |
 | --- | --- | --- | --- |
 | Core Web Vitals (this article) | A standardized, user-centered field score for any page | Can't measure app-specific moments | (this article) |
-| [Custom performance metrics](./custom-performance-metrics.md) | You need to time a domain-specific event (chart ready, results shown) | Not standardized or comparable across sites | `Custom Performance Metrics` |
-| [Perceived vs actual performance](./perceived-vs-actual-performance.md) | The felt speed differs from the measured one (skeletons, optimistic UI) | Qualitative; harder to gate on | `Perceived vs Actual Performance` |
+| Custom performance metrics | You need to time a domain-specific event (chart ready, results shown) | Not standardized or comparable across sites | `Custom Performance Metrics` (planned) |
+| Perceived vs actual performance | The felt speed differs from the measured one (skeletons, optimistic UI) | Qualitative; harder to gate on | `Perceived vs Actual Performance` (planned) |
 
 ## Bad Example
 
@@ -300,9 +300,9 @@ See the [Performance Engineering anti-patterns](../../../anti-patterns/README.md
 
 ## Related Articles
 
-- [Lab vs Field Measurement](./lab-vs-field-measurement.md) — why the lab estimate and the field score diverge, and when each is right.
-- [Perceived vs Actual Performance](./perceived-vs-actual-performance.md) — the gap between what the metrics say and what users feel.
-- [Custom Performance Metrics](./custom-performance-metrics.md) — measuring app-specific moments the Vitals can't see.
+- Lab vs Field Measurement (planned) — why the lab estimate and the field score diverge, and when each is right.
+- Perceived vs Actual Performance (planned) — the gap between what the metrics say and what users feel.
+- Custom Performance Metrics (planned) — measuring app-specific moments the Vitals can't see.
 - [Code Splitting](./code-splitting.md) — the main lever for the JavaScript that hurts LCP and INP.
 
 ## References

--- a/docs/05-reliability-quality/performance/resource-prefetch-and-preload.md
+++ b/docs/05-reliability-quality/performance/resource-prefetch-and-preload.md
@@ -142,8 +142,8 @@ Hints don't reduce how much has to load; they change *when*. Their alternatives 
 | --- | --- | --- | --- |
 | Resource hints (this article) | A critical resource is discovered late, or a next nav is predictable | Adds bandwidth cost; brittle if mis-typed | (this article) |
 | [Code Splitting](./code-splitting.md) | The problem is too much JavaScript, not its timing | Adds requests and loading states | `Code Splitting` |
-| [Critical CSS & Above-the-Fold](./critical-css-and-above-the-fold.md) | Render-blocking CSS delays first paint | Build complexity | `Critical CSS & Above-the-Fold` |
-| [Font & Asset Loading Strategy](./font-and-asset-loading-strategy.md) | Fonts/assets need a full loading policy, not one hint | Broader effort than a single tag | `Font & Asset Loading Strategy` |
+| Critical CSS & Above-the-Fold | Render-blocking CSS delays first paint | Build complexity | `Critical CSS & Above-the-Fold` (planned) |
+| Font & Asset Loading Strategy | Fonts/assets need a full loading policy, not one hint | Broader effort than a single tag | `Font & Asset Loading Strategy` (planned) |
 
 ## Bad Example
 
@@ -258,7 +258,7 @@ See the [Performance Engineering anti-patterns](../../../anti-patterns/README.md
 
 - [The Critical Rendering Path](./the-critical-rendering-path.md) — why late-discovered critical resources need a hint at all.
 - [Code Splitting](./code-splitting.md) — pairs with `modulepreload`/prefetch to load chunks at the right time.
-- [Font & Asset Loading Strategy](./font-and-asset-loading-strategy.md) — the full policy that font preloading is one part of.
+- Font & Asset Loading Strategy (planned) — the full policy that font preloading is one part of.
 - [Core Web Vitals (LCP, INP, CLS)](./core-web-vitals-lcp-inp-cls.md) — preloading the LCP element is a direct lever on LCP.
 
 ## References

--- a/docs/05-reliability-quality/performance/the-critical-rendering-path.md
+++ b/docs/05-reliability-quality/performance/the-critical-rendering-path.md
@@ -102,7 +102,7 @@ The model tells you where each lever acts. `defer` moves a script off the parser
 
 Get scripts off the parser-blocking path. Add `defer` to scripts that touch the DOM (they run in order after parsing) and `async` to independent third-party scripts. A plain `<script>` in the `<head>` is the most common render-blocking mistake; there is almost always a better attribute for it.
 
-Inline critical CSS and defer the rest. Extract the styles needed for above-the-fold content, inline them in a `<style>` in the head, and load the full stylesheet without blocking (for example with a `media`-swap `<link>` or an async loader). This cuts the render-blocking CSS to the minimum. See [Critical CSS & Above-the-Fold](./critical-css-and-above-the-fold.md).
+Inline critical CSS and defer the rest. Extract the styles needed for above-the-fold content, inline them in a `<style>` in the head, and load the full stylesheet without blocking (for example with a `media`-swap `<link>` or an async loader). This cuts the render-blocking CSS to the minimum. See Critical CSS & Above-the-Fold (planned).
 
 Minimize the number and size of critical resources. Every render- or parser-blocking file is a round trip before paint. Bundle where it reduces requests, drop `@import` (which serializes CSS fetches), and delete blocking resources that don't affect the first view. Fewer critical bytes and fewer critical files both shorten the path.
 
@@ -141,7 +141,7 @@ The critical rendering path is a browser mechanism, not a choice — `alternativ
 | --- | --- | --- | --- |
 | Critical-path analysis (this article) | Understanding *what* blocks first paint | Conceptual; needs the levers below to act | (this article) |
 | [Code Splitting](./code-splitting.md) | Script bytes dominate the path | Adds requests and loading states | `Code Splitting` |
-| [Critical CSS & Above-the-Fold](./critical-css-and-above-the-fold.md) | Render-blocking CSS delays paint | Build complexity, byte duplication | `Critical CSS & Above-the-Fold` |
+| Critical CSS & Above-the-Fold | Render-blocking CSS delays paint | Build complexity, byte duplication | `Critical CSS & Above-the-Fold` (planned) |
 | [Resource Prefetch & Preload](./resource-prefetch-and-preload.md) | A critical resource is discovered too late | Over-hinting wastes bandwidth | `Resource Prefetch & Preload` |
 
 ## Bad Example
@@ -253,7 +253,7 @@ See the [Performance Engineering anti-patterns](../../../anti-patterns/README.md
 ## Related Articles
 
 - [Code Splitting](./code-splitting.md) — cuts the JavaScript bytes that sit on the path.
-- [Critical CSS & Above-the-Fold](./critical-css-and-above-the-fold.md) — how to build the inlined critical set.
+- Critical CSS & Above-the-Fold (planned) — how to build the inlined critical set.
 - [Resource Prefetch & Preload](./resource-prefetch-and-preload.md) — hints that fix late-discovered critical resources.
 - [Core Web Vitals (LCP, INP, CLS)](./core-web-vitals-lcp-inp-cls.md) — LCP is the metric the path most directly moves.
 


### PR DESCRIPTION
Adds four performance engineering guides, indexes them, and replaces links to unpublished articles with planned references.