### PR TITLE
docs: add closures and WCAG guides

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -30,7 +30,9 @@
     "unfocusable", "unrepresentable", "unsanitized", "unsourced", "userbase", "versionable",
     "Clickjacking", "Metaprogramming", "Overcorrecting", "Subresource", "Unshareable", "unreviewed",
     "Anson", "endgroup", "lycheeverse", "nullglob", "shopt",
-    "contentful", "janky", "unthrottled", "prerender", "prerendering", "overcorrects"
+    "contentful", "janky", "unthrottled", "prerender", "prerendering", "overcorrects",
+    "focusable", "focusability", "perceivable", "conformance", "swappable", "currying",
+    "reachability", "teardown", "collectable", "unsubscribe", "dropdown", "ECMAScript"
   ],
   "ignorePaths": [
     "_to_delete/**",

--- a/docs/01-core-languages/javascript/closures.md
+++ b/docs/01-core-languages/javascript/closures.md
@@ -1,0 +1,262 @@
+---
+title: "Closures"
+slug: closures
+description: "A closure is a function bundled with the lexical environment it was defined in, letting it read and update outer variables long after that scope returns."
+keywords: ["closure", "lexical scope", "lexical environment", "captured variables", "encapsulation", "memory leak", "JavaScript functions", "private state"]
+part: "01 · Core Languages"
+domain: "JavaScript"
+subcategory: "Scope & Closures"
+difficulty: "Foundational"
+reading_time_min: 12
+priority: "Critical"
+status: "Published"
+canonical: true
+last_reviewed: "2026-07-26"
+prerequisites:
+  - "Lexical Scope"
+  - "Primitives & Wrappers"
+related:
+  - "Lexical Scope"
+  - "Hoisting & TDZ"
+  - "Block vs Function Scope"
+next:
+  - "Hoisting & TDZ"
+alternatives: []
+common_mistakes:
+  - "anti-patterns/README.md#javascript"
+  - "#common-mistakes"
+frameworks: []
+references:
+  - { title: "MDN — Closures", url: "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures" }
+  - { title: "ECMAScript — Execution Contexts and Environment Records", url: "https://tc39.es/ecma262/#sec-execution-contexts" }
+  - { title: "MDN — Memory management", url: "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Memory_management" }
+---
+
+# Closures
+
+> A closure is a function packaged together with the variables that were in scope where it was defined. It keeps reading and writing those variables even after the outer function has returned.
+
+**Part:** [01 · Core Languages](../) · **Domain:** JavaScript · **Priority:** Critical · **Difficulty:** Foundational · **Reading time:** ~12 min
+
+## TL;DR
+
+A *closure* is the pairing of a function with the lexical environment in which it was created. Because JavaScript resolves free variables by where a function is written, not where it is called, an inner function keeps a live reference to its outer variables even after the outer call has returned. This is the mechanism behind private state, factory functions, event handlers that remember their setup, and most of the "how does this callback still know that value?" moments in real code. The cost is that a captured variable cannot be garbage-collected while the closure is reachable, so a long-lived closure over a large object is a memory leak waiting to happen. Capture the minimum you need, and release closures when their owner is torn down.
+
+> **Recommendation:** Reach for a closure to encapsulate state that a set of functions must share privately; keep the captured set small, and drop the reference (remove the listener, clear the timer) when the closure's lifetime ends.
+
+## At a Glance
+
+| | |
+| --- | --- |
+| **Use when** | A function must remember state across calls, or several functions must share private, non-global state. |
+| **Avoid when** | The state is better modeled as an explicit object field, or the captured value is large and long-lived. |
+| **Alternatives** | Closures are a language primitive, not a swappable technique — the near neighbors are object fields and module state, not substitutes. |
+| **Primary risk** | Retaining a large captured environment past its usefulness — a leak that grows over a session. |
+| **Maturity** | Stable — part of the language since its first edition. |
+
+## Prerequisites
+
+This article assumes you understand how a function body resolves variable names against its surrounding scope, and the difference between a value and a reference.
+
+- Lexical Scope (planned) — closures are the runtime consequence of lexical scoping, so the scoping rules come first.
+- Primitives & Wrappers (planned) — what is captured "by reference" versus what behaves as a copied value.
+
+## Overview
+
+A *closure* is created every time a function is defined: the function value carries a hidden link to the environment record of the scope it was born in. When the function later runs and refers to a variable it did not declare itself — a *free variable* — the engine walks that chain of environments outward until it finds the binding. The important part is *when* that link is fixed: at definition time, by position in the source, not at call time by who invoked it.
+
+This is why an inner function returned from an outer one still works after the outer call is gone. The outer function's local variables would normally be discarded when it returns, but if a surviving inner function still references them, the engine keeps that environment alive. The closure is not a copy of the values; it is a live view of the same bindings, so two closures over the same variable see each other's writes. Closures are often confused with objects (both bundle behavior with state) and with simple callbacks (not every callback closes over anything), but the defining trait is the retained link to an outer scope.
+
+## The Problem
+
+Consider a module that needs a counter shared by a few functions but hidden from the rest of the app. The naive options are both bad: a module-level `let` is visible and mutable by anything in the file, and threading the count through every function signature is noisy and easy to get wrong. You want state that a small group of functions can read and update, and nothing else can touch.
+
+The second, sharper problem is the one closures cause rather than solve. Because a closure keeps its whole surrounding environment reachable, a handler that captures one small field can accidentally pin a large object graph in memory. A classic case: an event listener defined inside a component closes over the component's entire props or a big data array, and because the listener is never removed, the array outlives the component forever. The problem is not "use closures" versus "don't"; it is understanding exactly what a closure holds onto and for how long.
+
+## Why It Matters
+
+Closures are not an advanced trick you can skip — they are how ordinary JavaScript already works, so misreading them produces bugs that look like magic. The single most common interview-and-production trap, a loop that captures the wrong variable, is a closure misunderstanding. So is the stale-value bug where a callback reads an old copy of state because it closed over a binding that has since been replaced. Getting the mental model right turns these from mysteries into predictable outcomes.
+
+On the systems side, closures are a leading cause of front-end memory growth. Every retained listener, timer, or subscription that closes over component state is a potential leak, and leaks in a long-lived single-page app accumulate silently until the tab is sluggish. Because the leak is invisible in a quick test and only shows up after minutes of use, it is exactly the kind of defect that reaches production. Understanding what a closure captures is what lets you reason about — and cap — that cost.
+
+## Mental Model
+
+Think of a function as a note that says "look up `count` in the room I was written in." When you carry that note to another room and read it, it still points back to the original room. As long as the note exists, that room cannot be demolished, because the note might need it. A closure is the note plus the room it points to.
+
+```mermaid
+flowchart LR
+    Outer["makeCounter() scope<br/>count = 0"]
+    Inc["increment()<br/>(free var: count)"]
+    Get["current()<br/>(free var: count)"]
+    Outer --> Inc
+    Outer --> Get
+    Inc -. "reads & writes" .-> Outer
+    Get -. "reads" .-> Outer
+    Caller["caller keeps<br/>increment / current"] --> Inc
+    Caller --> Get
+```
+
+Two properties fall out of this model. First, closures over the *same* scope share it: `increment` and `current` above see one `count`, so a write from one is visible to the other. Second, a variable stays alive precisely as long as *some* reachable closure references it — no more, no less. That single rule explains both the feature (state persists) and the failure (memory persists). If you can name what is reachable, you can predict both.
+
+## Best Practices
+
+Capture the minimum. If a handler only needs an id, close over the id, not the whole object that contains it. Pulling the small value into a local before defining the inner function shrinks what the closure pins in memory.
+
+Prefer closures for genuinely private state. When a few functions must share state that nothing else should reach, a closure (or a module scope) expresses that better than a public field a caller could mutate. This is the "module pattern" and the reason factory functions are so common.
+
+Release closures at end of life. A closure held by a listener, timer, or subscription lives as long as that registration does. Remove the listener, clear the interval, and unsubscribe on teardown so the captured environment becomes collectable.
+
+Beware the loop variable. In a loop, decide deliberately whether each iteration's callback should see that iteration's value (use `let`, which creates a fresh binding per iteration) or a single shared value (use `var` or an outer variable). The bug is almost always an accidental share.
+
+## Trade-offs
+
+Closures trade a small, invisible memory commitment for expressive, encapsulated state. For short-lived or small captures the trade is free; for large, long-lived captures it becomes the dominant cost.
+
+**Advantages**
+
+- Encapsulation without classes: private state that only a chosen set of functions can touch.
+- State that persists across calls without a global or an extra parameter.
+- The foundation for callbacks, factories, currying, and most functional patterns.
+
+**Disadvantages**
+
+- A captured variable cannot be collected while the closure is reachable, so careless capture leaks memory.
+- The "live shared binding" semantics surprise people expecting a snapshot copy.
+- Over-using closures for state that belongs on an object can obscure data flow.
+
+| Dimension | Closures | Cost / caveat |
+| --- | --- | --- |
+| Expressiveness | Private, persistent state with no boilerplate | Easy to hide state that would be clearer as a field |
+| Memory | Only what is captured stays alive | A large capture pins its whole environment |
+| Correctness | Deterministic once the model is clear | Loop-variable and stale-value bugs if it is not |
+| Performance | Cheap to create and call | Many long-lived closures add GC pressure |
+
+## Alternative Approaches
+
+Closures are a language primitive rather than one option among interchangeable techniques, so there is no true substitute for the mechanism itself. What competes is *where you put shared state*: a closure keeps it in a scope, whereas an object keeps it in a field and a module keeps it in module scope. Choose an object when the state is naturally "the thing's data" and callers legitimately need access; choose a closure when the state must stay private to a set of collaborating functions.
+
+## Bad Example
+
+A per-row handler defined in a loop that closes over the loop variable, plus a listener that captures a large array and is never removed.
+
+```js
+// ❌ Two closure bugs in one place.
+function attachRowHandlers(rows, hugeDataset) {
+  for (var i = 0; i < rows.length; i++) {
+    // BUG 1: every handler closes over the SAME `i` (var is function-scoped),
+    // so by the time any click fires, `i` is rows.length — all handlers read
+    // the last index.
+    rows[i].addEventListener('click', function () {
+      console.log('clicked row', i);
+    });
+  }
+
+  // BUG 2: this listener closes over `hugeDataset`, and nothing ever removes it,
+  // so the entire array is retained for the life of the document.
+  window.addEventListener('resize', function () {
+    console.log('rows:', rows.length, 'records:', hugeDataset.length);
+  });
+}
+```
+
+**What goes wrong:** The `var i` binding is shared by every iteration's closure, so all handlers log the final index — the canonical loop-closure bug. Separately, the `resize` listener pins `hugeDataset` in memory permanently because the closure is reachable from a global event target and is never detached: a steady memory leak that a short test never reveals.
+
+## Good Example
+
+The same feature with a per-iteration binding, a minimal capture, and explicit teardown that releases every closure.
+
+```js
+// ✅ Fresh binding per iteration, minimal capture, and cleanup.
+function attachRowHandlers(rows, hugeDataset) {
+  const count = hugeDataset.length; // capture only the number, not the array
+
+  for (const [index, row] of rows.entries()) {
+    // `index` is a fresh binding each iteration, so each handler sees its own.
+    row.addEventListener('click', () => {
+      console.log('clicked row', index);
+    });
+  }
+
+  const onResize = () => {
+    console.log('rows:', rows.length, 'records:', count);
+  };
+  window.addEventListener('resize', onResize);
+
+  // Return a cleanup function so the caller can release the closures at end of life.
+  return () => {
+    window.removeEventListener('resize', onResize);
+  };
+}
+```
+
+**Why it's better:** Iterating with `for...of` (or `let`) gives each handler its own `index`, fixing the shared-variable bug. The `resize` handler closes over `count`, a single number, instead of the whole dataset, so the array is free to be collected once the caller drops it. Returning a cleanup function makes the listener's lifetime explicit, so the closure — and anything it captured — is released on teardown instead of leaking.
+
+## Production Example
+
+The module pattern: a factory that returns functions sharing one private, non-global piece of state, with no way for callers to reach it directly.
+
+```js
+// A rate limiter whose internal state is captured, not exposed.
+function createRateLimiter({ max, windowMs }) {
+  let hits = [];
+
+  function allow() {
+    const now = Date.now();
+    // Drop timestamps outside the window; `hits` is private to these functions.
+    hits = hits.filter((t) => now - t < windowMs);
+    if (hits.length >= max) return false;
+    hits.push(now);
+    return true;
+  }
+
+  function reset() {
+    hits = [];
+  }
+
+  // Callers get behavior, never the `hits` array itself.
+  return { allow, reset };
+}
+
+const limiter = createRateLimiter({ max: 5, windowMs: 1000 });
+if (limiter.allow()) {
+  // ...perform the guarded action
+}
+```
+
+The returned `allow` and `reset` both close over the same `hits` binding, so they coordinate through shared private state that nothing outside the factory can read or corrupt. Because `hits` only holds recent timestamps and is pruned on each call, the captured state stays bounded — the closure keeps state alive deliberately, not accidentally.
+
+## Common Mistakes
+
+See the [JavaScript anti-patterns](../../../anti-patterns/README.md#javascript) for the domain catalog. Concept-specific:
+
+### Mistake: Capturing the loop variable with `var`
+
+- **Symptom:** Every callback created in a loop reads the same final value instead of its own iteration's value.
+- **Why it fails:** `var` has one function-scoped binding shared by all iterations, so each closure references the same variable, which ends at its last value.
+- **Fix:** Use `let` or `for...of`, which create a fresh binding per iteration, or pass the value into an immediately-invoked function to capture it explicitly.
+
+### Mistake: Closing over more than you need
+
+- **Symptom:** Memory grows over a session; a heap snapshot shows large objects retained by handler closures long after the UI that created them is gone.
+- **Why it fails:** A closure keeps its entire surrounding environment reachable, so capturing a big object (or `this`) pins it until the closure itself is released.
+- **Fix:** Pull the minimal value into a local before defining the inner function, and remove listeners, timers, and subscriptions on teardown.
+
+## Checklist
+
+- [ ] Callbacks created in a loop use `let` or `for...of` when each should see its own value.
+- [ ] Long-lived closures (listeners, timers, subscriptions) capture the smallest value needed, not whole objects.
+- [ ] Every registration that holds a closure has a matching teardown (remove, clear, unsubscribe).
+- [ ] Private state shared by several functions is expressed with a closure or module scope, not a public field callers can mutate.
+- [ ] Where a snapshot is intended, the value is copied at capture rather than read live from a shared binding.
+
+## Related Articles
+
+- Lexical Scope (planned) — the name-resolution rules that closures are built on.
+- Hoisting & TDZ (planned) — how bindings come into existence within a scope before a closure reads them.
+- Block vs Function Scope (planned) — why `let` and `var` capture so differently in loops.
+
+## References
+
+- [MDN — Closures](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures) — the canonical explanation with worked examples.
+- [ECMAScript — Execution Contexts and Environment Records](https://tc39.es/ecma262/#sec-execution-contexts) — the specification mechanism behind captured bindings.
+- [MDN — Memory management](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Memory_management) — reachability and garbage collection, which govern what a closure keeps alive.

--- a/docs/04-interface-engineering/accessibility/wcag-principles-pour.md
+++ b/docs/04-interface-engineering/accessibility/wcag-principles-pour.md
@@ -1,0 +1,219 @@
+---
+title: "WCAG Principles (POUR)"
+slug: wcag-principles-pour
+description: "WCAG's four POUR principles — Perceivable, Operable, Understandable, Robust — are the frame every accessibility success criterion hangs on and how to apply them."
+keywords: ["WCAG", "POUR", "perceivable", "operable", "understandable", "robust", "accessibility principles", "web accessibility", "success criteria"]
+part: "04 · Interface Engineering"
+domain: "Accessibility"
+subcategory: "Standards"
+difficulty: "Intermediate"
+reading_time_min: 12
+priority: "High"
+status: "Published"
+canonical: true
+last_reviewed: "2026-07-26"
+prerequisites:
+  - "The Document Outline · HTML & Document Semantics"
+  - "Prop Design & Contracts · Component & Interaction Design"
+related:
+  - "Conformance Levels"
+  - "The ARIA Model"
+  - "Accessible Name Computation"
+next:
+  - "Conformance Levels"
+  - "The ARIA Model"
+  - "Accessible Name Computation"
+  - "Role, Name, State"
+  - "The Tree & Assistive Tech"
+alternatives: []
+common_mistakes:
+  - "anti-patterns/README.md#accessibility"
+  - "#common-mistakes"
+frameworks: []
+references:
+  - { title: "W3C — Web Content Accessibility Guidelines (WCAG) 2.2", url: "https://www.w3.org/TR/WCAG22/" }
+  - { title: "W3C — WCAG 2 Overview", url: "https://www.w3.org/WAI/standards-guidelines/wcag/" }
+  - { title: "MDN — Accessibility", url: "https://developer.mozilla.org/en-US/docs/Web/Accessibility" }
+---
+
+# WCAG Principles (POUR)
+
+> WCAG organizes every accessibility requirement under four principles — Perceivable, Operable, Understandable, Robust. Learn the frame, and the individual rules stop feeling arbitrary.
+
+**Part:** [04 · Interface Engineering](../) · **Domain:** Accessibility · **Priority:** High · **Difficulty:** Intermediate · **Reading time:** ~12 min
+
+## TL;DR
+
+The *WCAG principles*, remembered as **POUR**, are the top of a four-level hierarchy — principles, guidelines, success criteria, techniques — that the Web Content Accessibility Guidelines use to structure every requirement. Content must be **Perceivable** (users can sense it), **Operable** (users can drive it), **Understandable** (users can make sense of it), and **Robust** (it works across browsers and assistive technologies, now and later). The principles are not testable checks themselves; the *success criteria* under them are, and each criterion is tagged A, AA, or AAA. Treating POUR as a design lens — not an after-the-fact audit — catches whole classes of barrier early, because most real defects are a principle violated at the point a component was built. Use it to reason about *who* is excluded and *how*, then let the specific success criteria tell you the pass threshold.
+
+> **Recommendation:** Design and review against the four principles from the start; target the AA success criteria as your default bar, and reach for automated tools only to confirm what principled design already got right.
+
+## At a Glance
+
+| | |
+| --- | --- |
+| **Use when** | Framing any accessibility decision, from a single component to an audit scope — POUR is the shared vocabulary. |
+| **Avoid when** | You need a pass/fail gate — for that, drop to the specific success criteria and their A/AA/AAA level. |
+| **Alternatives** | POUR is the organizing model of WCAG itself; there is no competing frame you'd substitute for it. |
+| **Primary risk** | Treating the principles as slogans while skipping the concrete success criteria that actually define conformance. |
+| **Maturity** | Stable — unchanged in structure across WCAG 2.0, 2.1, and 2.2. |
+
+## Prerequisites
+
+This article assumes you can read a document's semantic structure and reason about a component's public contract, since both are where the principles are won or lost.
+
+- The Document Outline (planned, `· HTML & Document Semantics`) — headings and landmarks are how perceivable, operable structure is expressed.
+- Prop Design & Contracts (planned, `· Component & Interaction Design`) — accessible state is part of a component's contract, not an add-on.
+
+## Overview
+
+The *WCAG principles* are the four foundations — Perceivable, Operable, Understandable, Robust — beneath which the entire Web Content Accessibility Guidelines are organized. Under each principle sit *guidelines* (broad goals), under those sit *success criteria* (the testable statements you actually conform to), and under those sit *techniques* (specific, non-binding ways to meet a criterion). POUR is the acronym for the four principles and the fastest way to hold the whole standard in your head.
+
+The distinction that trips people up: the principles and guidelines are not themselves testable, and you never "pass POUR." What you conform to are the success criteria, each labeled Level A (must), AA (should, the common legal and organizational target), or AAA (enhanced, rarely required wholesale). The principles matter because they tell you *why* a criterion exists and *whom* it protects, which is exactly the reasoning an automated checker cannot supply. Think of POUR as the map and the success criteria as the coordinates.
+
+## The Problem
+
+Teams that approach accessibility as a checklist run it late, as an audit, and get a list of context-free failures: "image missing alt", "contrast 3.9:1", "button not focusable". Fixed one by one, these recur on the next feature because nobody internalized the underlying goal. The checklist tells you *what* failed but not *what class of user* was excluded or *why the rule exists*, so the team keeps learning the same lesson over again.
+
+The deeper problem is that accessibility barriers are created at design and build time and are expensive to retrofit. A custom dropdown built as clickable `<div>`s has no keyboard operation, no role, and no state — three principle violations baked into its structure. Discovered in an audit, it is a rewrite; considered while building, it is just "use the right element and wire up the states." Without a frame that connects the concrete rule to the human it serves, the work stays reactive and the same defects keep shipping.
+
+## Why It Matters
+
+Roughly one in six people live with a disability, and accessible design reaches far past that group: captions help in noisy rooms, high contrast helps in sunlight, and keyboard operability helps power users and anyone whose pointer just broke. Building to the principles widens your usable audience and, in many jurisdictions, is a legal requirement rather than a nicety — public-sector and large-commercial sites are increasingly held to WCAG AA by law.
+
+There is an engineering payoff too. The same semantics that make a page perceivable and operable for assistive technology also make it more robust for automated testing, better for SEO, and more resilient to browser change. Code that expresses real roles and states instead of faking them with generic elements is code that breaks less when the framework or the browser shifts underneath it. Accessibility done through the principles is not a tax on quality; it is a proxy for it.
+
+## Mental Model
+
+Read POUR as a chain that a user must complete to succeed, in order. Can they *perceive* the content? Then can they *operate* the controls? Then can they *understand* what happened? And will all of that keep working on their actual browser and assistive tech — is it *robust*? A break anywhere in the chain stops the user, no matter how well the other links hold.
+
+```mermaid
+flowchart LR
+    P["Perceivable<br/>can they sense it?"] --> O["Operable<br/>can they drive it?"]
+    O --> U["Understandable<br/>can they make sense of it?"]
+    U --> R["Robust<br/>does it work on their stack?"]
+    R --> Success["Task completed"]
+```
+
+Each link maps to concrete engineering. *Perceivable*: text alternatives for images, captions for media, sufficient color contrast, and content that does not rely on color alone. *Operable*: full keyboard access, visible focus, enough time, and no seizure-inducing motion. *Understandable*: predictable behavior, clear labels, and helpful error messages. *Robust*: valid, semantic markup with correct name/role/state so current and future assistive technologies can parse it. When a defect appears, naming which link it breaks points you straight at the class of fix.
+
+## Best Practices
+
+Start from native semantics. A real `<button>`, `<a>`, `<label>`, and heading structure satisfy large parts of all four principles for free — focusability, roles, keyboard behavior, and name computation come built in. This is the highest-leverage habit in the whole standard.
+
+Target AA by default. Level A is the floor and rarely enough; AAA is often impractical across a whole product. AA is the pragmatic, widely mandated bar, so make it your definition of done and treat individual AAA criteria as opportunistic wins.
+
+Design against the principles, audit against the criteria. Use POUR while building to ask "who can't perceive/operate/understand this?", then use the specific success criteria and their level to set the pass threshold and to communicate results.
+
+Don't stop at automated checks. Automated tools reliably catch only a minority of issues — roughly a third — because perception, operability, and understandability need human judgment. Pair every automated pass with a keyboard walkthrough and a screen-reader spot check.
+
+## Trade-offs
+
+Adopting the principles as a working frame costs some upfront learning and design attention in exchange for fewer, cheaper defects and a genuinely wider audience. The balance is strongly positive for any product with real users, but the effort is real and worth naming.
+
+**Advantages**
+
+- One vocabulary that connects every concrete rule to the user it protects, so fixes generalize.
+- Catches barriers at design time, when they are cheap, instead of in a late audit.
+- The semantics it drives also improve robustness, testability, and SEO.
+
+**Disadvantages**
+
+- The principles alone are not testable; you still need the detailed success criteria to define "done".
+- Full conformance, especially at AAA, can constrain visual and interaction choices.
+- Judgment-heavy criteria resist automation, so manual testing time is unavoidable.
+
+| Dimension | Designing to POUR | Cost / caveat |
+| --- | --- | --- |
+| Defect cost | Barriers caught early, at build time | Requires the team to learn the frame |
+| Audience | Reaches disabled users and many situational cases | Some AAA criteria limit design freedom |
+| Robustness | Semantic markup survives browser/AT change | More care per component up front |
+| Verification | Principles guide manual review | Not directly testable; needs criteria + human passes |
+
+## Alternative Approaches
+
+POUR is the organizing structure of WCAG itself, so there is no competing framework you would swap in for the same job — other guidance (platform-specific accessibility rules, ARIA authoring practices) sits *beneath* or *alongside* the principles rather than replacing them. The only real "alternative" is the anti-pattern of skipping a frame entirely and chasing individual audit findings, which this article exists to argue against.
+
+## Bad Example
+
+A "button" built from a generic element, styled to look right but violating three of the four principles at once.
+
+```html
+<!-- ❌ Looks like a button, fails Operable, Understandable, and Robust. -->
+<div class="btn" onclick="submitForm()">Submit</div>
+```
+
+```css
+.btn {
+  background: #7aa7ff; /* on white: ~2.3:1 contrast — fails Perceivable too */
+  color: #ffffff;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+```
+
+**What goes wrong:** The `<div>` is not focusable and has no keyboard handler, so it cannot be reached or activated without a mouse (**Operable** fails). It exposes no button role or accessible name to assistive tech, so a screen reader announces nothing meaningful (**Robust** and **Understandable** fail). And the low-contrast text falls under the AA threshold (**Perceivable** fails). One innocuous component breaks the chain at every link.
+
+## Good Example
+
+The same control as a native button with sufficient contrast — satisfying all four principles with less code.
+
+```html
+<!-- ✅ Native semantics give focusability, role, name, and keyboard activation. -->
+<button type="submit" class="btn">Submit</button>
+```
+
+```css
+.btn {
+  background: #2f5fd0; /* on white: ~5.9:1 — passes AA for normal text */
+  color: #ffffff;
+  padding: 8px 16px;
+  border-radius: 6px;
+}
+
+/* Operable: keep a visible focus indicator for keyboard users. */
+.btn:focus-visible {
+  outline: 3px solid #1b2a4a;
+  outline-offset: 2px;
+}
+```
+
+**Why it's better:** A real `<button>` is focusable, is announced with the button role and its text as the accessible name, and responds to both Enter and Space with no extra code — **Operable**, **Understandable**, and **Robust** handled by the platform. Raising the background to a ~5.9:1 ratio clears the AA contrast criterion, restoring **Perceivable**. The principled version is also simpler, because it stops fighting the element the browser already ships.
+
+## Common Mistakes
+
+See the [Accessibility anti-patterns](../../../anti-patterns/README.md#accessibility) for the domain catalog. Concept-specific:
+
+### Mistake: Treating POUR as the testable thing
+
+- **Symptom:** A report claims the page "meets Perceivable" with no reference to specific success criteria or a conformance level.
+- **Why it fails:** Principles and guidelines are not testable; only the success criteria are, and conformance is always stated at Level A, AA, or AAA.
+- **Fix:** Map each principle to the concrete criteria you tested and record the level you met, so "accessible" has a defined meaning.
+
+### Mistake: Equating an automated pass with conformance
+
+- **Symptom:** A green automated scan is presented as proof the product is accessible.
+- **Why it fails:** Automated tools detect only a fraction of issues; operability and understandability barriers routinely pass a machine check.
+- **Fix:** Treat automated results as a floor, then add keyboard and screen-reader passes against the relevant criteria.
+
+## Checklist
+
+- [ ] Every interactive control uses a native element or a correct role, name, and state (Robust, Operable).
+- [ ] All non-text content has a text alternative, and color is never the only signal (Perceivable).
+- [ ] The whole interface is reachable and operable by keyboard with a visible focus indicator (Operable).
+- [ ] Labels, instructions, and error messages are clear and behavior is predictable (Understandable).
+- [ ] Text meets at least the AA contrast ratio for its size (Perceivable).
+- [ ] Conformance is stated against specific success criteria and a target level, not "POUR".
+
+## Related Articles
+
+- Conformance Levels (planned) — what Level A, AA, and AAA mean and which to target.
+- The ARIA Model (planned) — how roles, states, and properties fill gaps native HTML can't.
+- Accessible Name Computation (planned) — how assistive tech derives the name that makes a control understandable.
+
+## References
+
+- [W3C — Web Content Accessibility Guidelines (WCAG) 2.2](https://www.w3.org/TR/WCAG22/) — the normative standard and its full set of success criteria.
+- [W3C — WCAG 2 Overview](https://www.w3.org/WAI/standards-guidelines/wcag/) — the layered structure of principles, guidelines, criteria, and techniques.
+- [MDN — Accessibility](https://developer.mozilla.org/en-US/docs/Web/Accessibility) — practical, implementation-focused guidance mapped to the principles.


### PR DESCRIPTION
Adds standalone guides for JavaScript closures and WCAG's POUR accessibility principles, with spellcheck updates.