### PR TITLE
docs: remove obsolete lint directives

### DIFF
--- a/docs/01-core-languages/javascript/lexical-scope.md
+++ b/docs/01-core-languages/javascript/lexical-scope.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable MD007 MD032 -->
 ---
 title: "Lexical Scope"
 slug: lexical-scope
@@ -32,7 +31,6 @@ references:
   - { title: "MDN — Closures", url: "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Closures" }
   - { title: "ECMAScript — Environment Records", url: "https://tc39.es/ecma262/#sec-environment-records" }
 ---
-<!-- markdownlint-enable MD007 MD032 -->
 
 # Lexical Scope
 


### PR DESCRIPTION
Removes unnecessary Markdown lint suppression directives from the lexical scope guide.